### PR TITLE
feat: Add get_credential

### DIFF
--- a/src/keyrings/onepassword/credential.py
+++ b/src/keyrings/onepassword/credential.py
@@ -1,0 +1,17 @@
+from keyring.credentials import Credential
+
+
+class OnePasswordCredential(Credential):
+    def __init__(self, username: str | None, password: str) -> None:
+        self._username = username
+        self._password = password
+
+    @property
+    def username(self) -> str:
+        if self._username is None:
+            raise ValueError("credential has no username")
+        return self._username
+
+    @property
+    def password(self) -> str:
+        return self._password

--- a/src/keyrings/onepassword/keyring.py
+++ b/src/keyrings/onepassword/keyring.py
@@ -1,11 +1,14 @@
 import asyncio
+import logging
 import os
 
 from jaraco.classes import properties
 from keyring.backend import KeyringBackend
+from keyring.credentials import Credential
 
 from onepassword.client import Client
 
+from .credential import OnePasswordCredential
 from .version import __version__
 
 _AUTH_ENV_VAR = "OP_SERVICE_ACCOUNT_TOKEN"
@@ -39,6 +42,7 @@ class OnePasswordKeyring(KeyringBackend):
 
     def __init__(self) -> None:
         super().__init__()  # type: ignore[no-untyped-call]
+        self.client = asyncio.run(get_client())
 
     @classmethod
     @properties.classproperty
@@ -53,21 +57,37 @@ class OnePasswordKeyring(KeyringBackend):
     def vault(self) -> str:
         return os.getenv(_BACKEND_VAULT_ENV_VAR, _DEFAULT_KEYRING_VAULT)
 
-    async def _get_password(self, service: str) -> str | None:
-        secret_reference = f"op://{self.vault}/{service}/password"
+    async def _get_attribute(self, service: str, attribute: str) -> str | None:
+        secret_reference = f"op://{self.vault}/{service}/{attribute}"
         try:
-            client = await get_client()
-            return await client.secrets.resolve(secret_reference)
+            return await self.client.secrets.resolve(secret_reference)
         # TODO: Catch 1Password specific errors only?
         except Exception as ex:
-            print(ex)
+            logging.debug(f"Failed to resolve {secret_reference}: {ex}")
             return None
+
+    async def _get_credential(
+        self, service: str, username: str | None
+    ) -> Credential | None:
+        op_username = await self._get_attribute(service, "username")
+        if username is not None and op_username != username:
+            return None
+        op_password = await self._get_attribute(service, "password")
+        if op_password is not None:
+            return OnePasswordCredential(
+                username=op_username,
+                password=op_password,
+            )
+        return None
 
     def set_password(self, service: str, username: str, password: str) -> None:
         pass
 
     def get_password(self, service: str, username: str) -> str | None:
-        return asyncio.run(self._get_password(service))
+        return asyncio.run(self._get_attribute(service, "password"))
 
     def delete_password(self, service: str, username: str) -> None:
         pass
+
+    def get_credential(self, service: str, username: str | None) -> Credential | None:
+        return asyncio.run(self._get_credential(service, username))


### PR DESCRIPTION
Implement the `get_credential` method. Since 1Password credentials might not have a username, we return an empty string if `OnePasswordCredential.username` is `None`.
